### PR TITLE
Alterohm changes 2020 06 01 1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+PosteRazor 1.9.7
+================
+(Preview version for the upcoming Qt-based PosteRazor 2)
+- Changed: Various small fixes
+-   Added: Danish translation by Henrik Troels-Hansen
+-   Added: Czech translation by Filip Pivarči
+
 PosteRazor 1.9.6
 ================
 (Preview version for the upcoming Qt-based PosteRazor 2)

--- a/README
+++ b/README
@@ -3,6 +3,7 @@ Description:
 
 Homepage:
   http://posterazor.sourceforge.net/
+  https://github.com/aportale/posterazor
 
 Maintainer:
   Alessandro Portale <alessandro _at_ casaportale _dot_ de>

--- a/packaging/iss/posterazor.iss
+++ b/packaging/iss/posterazor.iss
@@ -1,6 +1,6 @@
 #define APPLICATIONTITLE "PosteRazor"
-#define VERSION "1.9.5"
-#define COPYRIGHT "2005-2008 Alessandro Portale"
+#define VERSION "1.9.7"
+#define COPYRIGHT "2005-2020 Alessandro Portale"
 #define PREFERENCESDIR "{userappdata}\CasaPortale"
 #define PREFERENCESFILE PREFERENCESDIR + "\PosteRazor.ini"
 #define WEBSITE "http://posterazor.sourceforge.net/"

--- a/src/Info.plist
+++ b/src/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>PosteRazor</string>
 	<key>CFBundleGetInfoString</key>
-	<string>PosteRazor 1.9.5, Copyright 2005-2008 Alessandro Portale, GNU General Public License</string>
+	<string>PosteRazor 1.9.7, Copyright 2005-2020 Alessandro Portale, GNU General Public License</string>
 	<key>CFBundleIconFile</key>
 	<string>posterazor</string>
 	<key>CFBundleIdentifier</key>
@@ -17,15 +17,15 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.5</string>
+	<string>1.9.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.9.5</string>
+	<string>1.9.7</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2005-2008 http://posterazor.sourceforge.net/</string>
+	<string>Copyright 2005-2020 http://posterazor.sourceforge.net/</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/src/posterazor.pro
+++ b/src/posterazor.pro
@@ -14,13 +14,16 @@ macx:ICON = \
     posterazor.icns
 
 macx:CONFIG += \
-    x86 ppc
+    x86
+#    x86 ppc
 
 macx:QMAKE_MAC_SDK = \
-    /Developer/SDKs/MacOSX10.4u.sdk
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
+#    /Developer/SDKs/MacOSX10.4u.sdk
 
 macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = \
-    10.3
+    10.7
+#    10.3
 
 RC_FILE += \
     posterazor.rc

--- a/src/posterazor.rc
+++ b/src/posterazor.rc
@@ -37,8 +37,8 @@ POSTERAZOR_ICON ICON "posterazor.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,9,5,0
- PRODUCTVERSION 1,9,5,0
+ FILEVERSION 1,9,7,0
+ PRODUCTVERSION 1,9,7,0
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -53,15 +53,15 @@ BEGIN
     BEGIN
         BLOCK "00000000"
         BEGIN
-            VALUE "Comments", "PosteRazor 1.9.5, Copyright 2005-2009 Alessandro Portale, GNU General Public License"
+            VALUE "Comments", "PosteRazor 1.9.7, Copyright 2005-2020 Alessandro Portale, GNU General Public License"
             VALUE "CompanyName", "Alessandro Portale www.casaportale.de"
             VALUE "FileDescription", "PosteRazor"
-            VALUE "FileVersion", "1.9.5"
-            VALUE "LegalCopyright", "Copyright (C) 2005-2009 Alessandro Portale"
+            VALUE "FileVersion", "1.9.7"
+            VALUE "LegalCopyright", "Copyright (C) 2005-2020 Alessandro Portale"
             VALUE "LegalTrademarks", "Alessandro Portale"
             VALUE "OriginalFilename", "posterazor.exe"
             VALUE "ProductName", "PosteRazor"
-            VALUE "ProductVersion", "1.9.5"
+            VALUE "ProductVersion", "1.9.7"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
- changed version info to 1.9.7 in some files
- changed copyright year info to 2005-2020 in some files
- changed qmake macx settings to compile project under current macos 10.15
- added github website to README
- added 1.9.7 info in CHANGES